### PR TITLE
Enhances Github actions to be more helpful with tests and dependency versions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,10 +8,10 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-latest ]
-#        operating-system: [ ubuntu-latest, windows-latest, macOS-latest ]
         php-versions: [ '8.0', '8.1' ]
+        stability: [prefer-lowest, prefer-stable]
     steps:
-    - name: Setup PHP
+    - name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
@@ -28,10 +28,10 @@ jobs:
         path: vendor
         key: ${{ runner.os }}-php-${{ matrix.php-versions }}-${{ hashFiles('**/composer.lock') }}
         restore-keys: |
-          ${{ runner.os }}-php-${{ matrix.php-versions }}-
+          ${{ runner.os }}-php-${{ matrix.php-versions }}-${{ matrix.stability }}
 
     - name: Install dependencies
-      run: composer install --prefer-dist --no-progress
+      run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
     - name: Test PHPUnit
       run: vendor/bin/phpunit


### PR DESCRIPTION
Hey there!

The current method of defining dependency versions using a version range (e.g., `>=0.1.0`) is rather unstable and is causing some problems. My proposal is that these packages be updated to utilize the [caret version constraint](https://getcomposer.org/doc/articles/versions.md#caret-version-range-) (e.g., `^0.1.0`) to align with semantic versioning and avoid breaking changes. This is the recommended approach by composer anyway.

This pull requests adjusts the Github actions and forces them to run with the lowest matching version and the most recent stable version so that we can accurately see how that causes tests to fail.